### PR TITLE
[os] run updatedb as part of image build

### DIFF
--- a/makefiles/in_chroot/install.sh
+++ b/makefiles/in_chroot/install.sh
@@ -170,6 +170,10 @@ systemctl enable gen_etc_issue.service
 cp software/configs/disable_kernel_messages.service /etc/systemd/system/
 systemctl enable disable_kernel_messages.service
 
+# configure plocate
+systemctl enable plocate-updatedb.timer
+updatedb
+
 # systemd is being stupid:
 sed -i 's/kernel.sysrq = 16/kernel.sysrq = 1/' /usr/lib/sysctl.d/50-default.conf
 

--- a/makefiles/in_chroot/requirements_pacman.txt
+++ b/makefiles/in_chroot/requirements_pacman.txt
@@ -46,7 +46,7 @@ python-numpy
 
 # various other packages
 lsof
-mlocate
+plocate
 stress
 screen
 minicom


### PR DESCRIPTION
This should make `locate` work on first boot.
Furthermore this activates the `systemd` timer to daily update the database.
Currently we are using the default config for `updatedb`:
```
PRUNE_BIND_MOUNTS = "yes"
PRUNEFS = "9p afs anon_inodefs auto autofs bdev binfmt_misc cgroup cifs coda configfs cpuset cramfs debugfs devpts devtmpfs ecryptfs exofs ftpfs fuse fuse.encfs fuse.s3fs fuse.sshfs fusectl gfs gfs2 hugetlbfs inotifyfs iso9660 jffs2 lustre mqueue ncpfs nfs nfs4 nfsd pipefs proc ramfs rootfs rpc_pipefs securityfs selinuxfs sfs shfs smbfs sockfs sshfs sysfs tmpfs ubifs udf usbfs vboxsf"
PRUNENAMES = ".git .hg .svn"
PRUNEPATHS = "/afs /media /mnt /net /sfs /tmp /udev /var/cache /var/lib/pacman/local /var/lock /var/run /var/spool /var/tmp"
```
Do we want to add any pruned paths?