### PR TITLE
[os] misc fixes

### DIFF
--- a/makefiles/in_chroot/install.sh
+++ b/makefiles/in_chroot/install.sh
@@ -197,7 +197,8 @@ mkdir -p $HASH_LOCATION
 rm -f $HASH_LOCATION/hashes.txt; rm -f $HASH_LOCATION/files.txt
 find $VERIFY_DIRECTORIES -type f > $HASH_LOCATION/files.txt
 # also hash file list
-echo "$HASH_LOCATION/files.txt" >> $HASH_LOCATION/files.txt
-hashdeep -c sha256 -f $HASH_LOCATION/files.txt > $HASH_LOCATION/hashes.txt
+
+# echo "$HASH_LOCATION/files.txt" >> $HASH_LOCATION/files.txt
+# hashdeep -c sha256 -f $HASH_LOCATION/files.txt > $HASH_LOCATION/hashes.txt
 
 echo "axiom-update finished. Software version is now $(git describe --always --abbrev=8 --dirty)."

--- a/makefiles/in_chroot/requirements_pacman.txt
+++ b/makefiles/in_chroot/requirements_pacman.txt
@@ -9,7 +9,6 @@ base-devel
 git
 figlet
 wget
-hashdeep
 pacman-contrib
 rsync
 
@@ -33,7 +32,7 @@ nano
 python-pip
 python-numpy
 dtc
-man
+man-db
 man-pages
 
 # webserver

--- a/makefiles/in_chroot/requirements_pacman.txt
+++ b/makefiles/in_chroot/requirements_pacman.txt
@@ -37,6 +37,7 @@ man-pages
 
 # webserver
 lighttpd
+nodejs-lts-jod
 yarn
 
 # python-stuff


### PR DESCRIPTION
remove hashdeep, as its no longer present in archlinux specify man-db instead of man, as there are two providers for man now